### PR TITLE
Added new `kicad_cli_path` parameter

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,15 @@
 
 
 #
+### **+05:30 04:24:41 PM 20-02-2025, Thursday**
+
+  - Added new `kicad_cli_path` configuration parameter.
+    - This will help users to use different versions of KiCad CLI without adding it to the System Path.
+    - `kicad_cli_path` will now be used by all generator functions.
+  - JSON configuration version updated to `1.3`.
+  - New Version 🆕 `v0.0.28`.
+
+#
 ### **+05:30 11:12:50 PM 13-02-2025, Thursday**
 
   - Added common layers support for SVG generation.
@@ -33,7 +42,7 @@
     - Added `svg` command.
     - Updated the JSON with SVG generation options.
     - Tested and working.
-  - New Version `0.0.27`.
+  - New Version 🆕 `0.0.27`.
 
 #
 ### **+05:30 11:02:36 PM 08-11-2024, Friday**
@@ -99,7 +108,7 @@
   - Added new `run` command and `run()` function.
     - This will generate files based on the provided JSON configuration file.
     - The configuration file can be anything.
-  - New Version `0.0.26`
+  - New Version 🆕 `0.0.26`
 
 #
 ### **+05:30 08:16:16 PM 02-11-2024, Saturday**
@@ -129,7 +138,7 @@
     - Arguments are now fetched and passed automatically to the `generate_interactive_bom.py` script.
     - The `--output-dir` command will be used instead of native `--dest-dir` command.
     - Tested and working correctly.
-  - New Version `0.0.25`.
+  - New Version 🆕 `0.0.25`.
 
 #
 ### **+05:30 04:10:26 PM 02-11-2024, Saturday**
@@ -150,7 +159,7 @@
     - Updated the merged PDF file's name format.
     - Enabled generating ZIP file with the merged PDF files.
     - Tested and working correctly.
-  - New Version `0.0.24`.
+  - New Version 🆕 `0.0.24`.
 
 #
 ### **+05:30 08:27:56 PM 19-10-2024, Saturday**
@@ -162,13 +171,13 @@
 ### **+05:30 10:12:46 PM 15-10-2024, Tuesday**
 
   - PCB PDF files are now saved as ZIP file also.
-  - New Version `0.0.23`.
+  - New Version 🆕 `0.0.23`.
 
 #
 ### **+05:30 09:49:11 PM 12-10-2024, Saturday**
 
   - Changed the final directory date format to `"YYYY-MM-DD"` from `"DD-MM-YYYY"`. This will help the directories to be sorted easily by name by default.
-  - New Version `0.0.22`.
+  - New Version 🆕 `0.0.22`.
 
 #
 ### **+05:30 11:47:28 PM 07-10-2024, Monday**
@@ -179,43 +188,43 @@
 ### **+05:30 08:23:25 PM 07-10-2024, Monday**
 
   - Fixed string quotes conflicts.
-  - New Version `0.0.21`.
+  - New Version 🆕 `0.0.21`.
 
 #
 ### **+05:30 05:08:48 PM 06-10-2024, Sunday**
 
   - Added JSON configuration support for `generateBom()`.
-  - New Version `0.0.20`.
+  - New Version 🆕 `0.0.20`.
 
 #
 ### **+05:30 04:46:12 PM 06-10-2024, Sunday**
 
   - Added JSON configuration support for `generate3D()`.
-  - New Version `0.0.19`.
+  - New Version 🆕 `0.0.19`.
 
 #
 ### **+05:30 03:33:44 PM 06-10-2024, Sunday**
 
   - Optimized the `generatePositions()` function.
-  - New Version `0.0.18`.
+  - New Version 🆕 `0.0.18`.
 
 #
 ### **+05:30 01:39:08 AM 06-10-2024, Sunday**
 
   - Added support JSON configuration for `generatePcbPdf()`.
   - Added color to the printed app info.
-  - New Version `0.0.17`.
+  - New Version 🆕 `0.0.17`.
 
 #
 ### **+05:30 12:26:25 AM 07-09-2024, Saturday**
 
   - `generateGerbers()` now reads the configuration `kie_include_drill` and generated the drill files first based on the value. Default value is `true`.
-  - New Version `0.0.16`.
+  - New Version 🆕 `0.0.16`.
 
 #
 ### **+05:30 12:02:33 AM 07-09-2024, Saturday**
 
-  - Bumped up the version to `0.0.15`.
+  - Bumped up the version to 🆕 `0.0.15`.
 
 #
 ### **+05:30 11:50:10 PM 06-09-2024, Friday**
@@ -239,7 +248,7 @@
 
   - Updated `generatePositions()` to use the JSON configuration file.
   - File generation is successful.
-  - New Version `0.0.14`.
+  - New Version 🆕 `0.0.14`.
 
 #
 ### **+05:30 12:23:41 AM 04-09-2024, Wednesday**
@@ -263,7 +272,7 @@
   - Added support for local JSON configuration file.
   - Updated `generateSchPdf()` to use output directory from the config file.
   - Added `load_config()` to load the custom and default configurations.
-  - New Version `0.0.13`.
+  - New Version 🆕 `0.0.13`.
 
 #
 ### **+05:30 12:41:33 PM 01-09-2024, Sunday**
@@ -277,14 +286,14 @@
 
   - Added `printInfo()` to print the app information.
   - Added `-v` and `--version` command to print the app version.
-  - New Version `0.0.12`.
+  - New Version 🆕 `0.0.12`.
 
 #
 ### **+05:30 11:16:59 AM 01-09-2024, Sunday**
 
   - Added `bom` command to export BoM file. Only CSV is supported at the moment.
   - Added `generateBom()` function.
-  - New Version `0.0.11`.
+  - New Version 🆕 `0.0.11`.
 
 #
 ### **+05:30 10:38:08 AM 01-09-2024, Sunday**
@@ -298,21 +307,21 @@
 
   - Added `ddd` command to export STEP and VRML files.
   - Added `generate3D()` function.
-  - New Version `0.0.10`.
+  - New Version 🆕 `0.0.10`.
 
 #
 ### **+05:30 11:10:42 PM 30-08-2024, Friday**
 
   - Added `generatePcbPdf()` to export the PCB as PDF files. Layers are imported in individual files with the `Edge.Cuts` as the common layer.
   - Added `pcb_pdf` command.
-  - New Version `0.0.9`.
+  - New Version 🆕 `0.0.9`.
 
 #
 ### **+05:30 10:40:59 PM 30-08-2024, Friday**
 
   - Added `generatePositions()` to export position/centroid files.
   - Added new command `positions`.
-  - New Version `0.0.8`.
+  - New Version 🆕 `0.0.8`.
 
 #
 ### **+05:30 09:38:10 PM 30-08-2024, Friday**
@@ -321,14 +330,14 @@
   - Drill files are now generated with the Gerbers.
   - All files in the Gerber target directory, except ZIP files are now deleted before overwriting. This fixes the rename conflicts.
   - If a ZIP file already exists, the new one will now get a new sequence number. This will keep single set of manufacturing files but multiple ZIP files.
-  - New Version `0.0.7`.
+  - New Version 🆕 `0.0.7`.
 
 #
 ### **+05:30 02:09:09 AM 30-08-2024, Friday**
 
   - Generated Gerber files are now renamed with the revision tag after the project name.
   - Gerber files are now compressed into a ZIP file using `zip_all_files()`.
-  - New Version `0.0.6`.
+  - New Version 🆕 `0.0.6`.
 
 #
 ### **+05:30 12:17:50 AM 30-08-2024, Friday**
@@ -337,14 +346,14 @@
   - Now creates Gerber output directory from project revision, current date and a sequence number.
   - `to_overwrite` in `generateGerbers()` function now controls whether or not to overwrite the existing Gerber files in the target directory.
   - Added `test` command and `test()` function.
-  - New Version `0.0.5`.
+  - New Version 🆕 `0.0.5`.
   
 #
 ### **+05:30 11:39:24 PM 29-08-2024, Thursday**
 
   - Output directory is now created if it does not exist, in `generateGerbers()` function.
   - KiCad-CLI commands will fail if the output directory does not exist.
-  - New Version `0.0.4`.
+  - New Version 🆕 `0.0.4`.
 
 #
 ### **+05:30 11:33:55 PM 29-08-2024, Thursday**
@@ -354,7 +363,7 @@
   - Added `extract_pcb_file_name()` to extract the file name from the path.
   - `generateGerbers()` now prints the KiCad PCB project name.
   - Code running successfully.
-  - New Version `0.0.3`.
+  - New Version 🆕 `0.0.3`.
 
 #
 ### **+05:30 11:18:09 PM 29-08-2024, Thursday**
@@ -363,7 +372,7 @@
   - Added `parseArguments()`.
   - Added `gerbers` command to export Gerber files.
   - `generateGerbers()` function now accepts the input PCB file name and the output directory path.
-  - New Version `0.0.2`.
+  - New Version 🆕 `0.0.2`.
 
 #
 ### **+05:30 10:45:47 PM 29-08-2024, Thursday**
@@ -372,4 +381,4 @@
   - Added `generateGerbers()` function.
   - Added Readme and Changes.
   - Added project info.
-  - New Version `0.0.1`.
+  - New Version 🆕 `0.0.1`.

--- a/kiexport.py
+++ b/kiexport.py
@@ -4,8 +4,8 @@
 # KiExport
 # Tool to export manufacturing files from KiCad PCB projects.
 # Author: Vishnu Mohanan (@vishnumaiea, @vizmohanan)
-# Version: 0.0.27
-# Last Modified: +05:30 19:36:27 PM 18-12-2024, Wednesday
+# Version: 0.0.28
+# Last Modified: +05:30 04:24:26 PM 20-02-2025, Thursday
 # GitHub: https://github.com/vishnumaiea/KiExport
 # License: MIT
 
@@ -23,7 +23,7 @@ import pymupdf
 #=============================================================================================#
 
 APP_NAME = "KiExport"
-APP_VERSION = "0.0.27"
+APP_VERSION = "0.0.28"
 
 SAMPLE_PCB_FILE = "Mitayi-Pico-D1/Mitayi-Pico-RP2040.kicad_pcb"
 
@@ -35,9 +35,10 @@ DEFAULT_CONFIG_JSON = '''
   "name": "KiExport.JSON",
   "description": "Configuration file for KiExport",
   "filetype": "json",
-  "version": "1.2",
+  "version": "1.3",
   "project_name": "Mitayi-Pico-RP2040",
   "commands": ["gerbers", "drills", "sch_pdf", "bom", "ibom", "pcb_pdf", "positions", "svg", ["ddd", "STEP"], ["ddd", "VRML"]],
+  "kicad_cli_path": "C:\\\\Program Files\\\\KiCad\\\\9.0\\\\bin\\\\kicad-cli.exe",
   "kicad_python_path": "C:\\\\Program Files\\\\KiCad\\\\8.0\\\\bin\\\\python.exe",
   "ibom_path": "C:\\\\Users\\\\vishn\\\\Documents\\\\KiCad\\\\8.0\\\\3rdparty\\\\plugins\\\\org_openscopeproject_InteractiveHtmlBom\\\\generate_interactive_bom.py",
   "data": {
@@ -464,6 +465,9 @@ def generateGerbers (output_dir, pcb_filename, to_overwrite = True):
   # Generate the drill files first if specified
   kie_include_drill = current_config.get ("data", {}).get ("gerbers", {}).get ("kie_include_drill", default_config ["data"]["gerbers"]["kie_include_drill"])
 
+  # Get the KiCad CLI path.
+  kicad_cli_path = f'{current_config.get ("kicad_cli_path", default_config ["kicad_cli_path"])}'
+
   # Check if the value is boolean and then true or false
   if isinstance (kie_include_drill, bool):
     kie_include_drill = str (kie_include_drill).lower()
@@ -479,7 +483,7 @@ def generateGerbers (output_dir, pcb_filename, to_overwrite = True):
   #---------------------------------------------------------------------------------------------#
   
   # Common base command
-  gerber_export_command = ["kicad-cli", "pcb", "export", "gerbers"]
+  gerber_export_command = [f'"{kicad_cli_path}"', "pcb", "export", "gerbers"]
 
   # Check if the pcb file exists
   if not check_file_exists (pcb_filename):
@@ -603,8 +607,11 @@ def generateGerbers (output_dir, pcb_filename, to_overwrite = True):
 #=============================================================================================#
 
 def generateDrills (output_dir, pcb_filename):
+  # Get the KiCad CLI path.
+  kicad_cli_path = f'{current_config.get ("kicad_cli_path", default_config ["kicad_cli_path"])}'
+
   # Common base command
-  drill_export_command = ["kicad-cli", "pcb", "export", "drill"]
+  drill_export_command = [f'"{kicad_cli_path}"', "pcb", "export", "drill"]
 
   # Check if the pcb file exists
   if not check_file_exists (pcb_filename):
@@ -710,8 +717,11 @@ def generatePositions (output_dir, pcb_filename, to_overwrite = True):
   global current_config  # Access the global config
   global default_config  # Access the global config
   
+  # Get the KiCad CLI path.
+  kicad_cli_path = f'{current_config.get ("kicad_cli_path", default_config ["kicad_cli_path"])}'
+
   # Common base command
-  position_export_command = ["kicad-cli", "pcb", "export", "pos"]
+  position_export_command = [f'"{kicad_cli_path}"', "pcb", "export", "pos"]
 
   # Check if the input file exists
   if not check_file_exists (pcb_filename):
@@ -856,8 +866,11 @@ def generatePositions (output_dir, pcb_filename, to_overwrite = True):
 #=============================================================================================#
 
 def generatePcbPdf (output_dir, pcb_filename, to_overwrite = True):
+  # Get the KiCad CLI path.
+  kicad_cli_path = f'{current_config.get ("kicad_cli_path", default_config ["kicad_cli_path"])}'
+
   # Common base command
-  pcb_pdf_export_command = ["kicad-cli", "pcb", "export", "pdf"]
+  pcb_pdf_export_command = [f'"{kicad_cli_path}"', "pcb", "export", "pdf"]
 
   # Check if the pcb file exists
   if not check_file_exists (pcb_filename):
@@ -1020,8 +1033,11 @@ def generateSchPdf (output_dir, sch_filename, to_overwrite = True):
   global current_config  # Access the global config
   global default_config  # Access the global config
 
+  # Get the KiCad CLI path.
+  kicad_cli_path = f'{current_config.get ("kicad_cli_path", default_config ["kicad_cli_path"])}'
+
   # Common base command
-  sch_pdf_export_command = ["kicad-cli", "sch", "export", "pdf"]
+  sch_pdf_export_command = [f'"{kicad_cli_path}"', "sch", "export", "pdf"]
 
   # Check if the input file exists
   if not check_file_exists (sch_filename):
@@ -1121,13 +1137,16 @@ def generateSchPdf (output_dir, sch_filename, to_overwrite = True):
 #=============================================================================================#
 
 def generate3D (output_dir, pcb_filename, type = "STEP", to_overwrite = True):
+  # Get the KiCad CLI path.
+  kicad_cli_path = f'{current_config.get ("kicad_cli_path", default_config ["kicad_cli_path"])}'
+
   # Common base command
   if type == "STEP" or type == "step":
-    ddd_export_command = ["kicad-cli", "pcb", "export", "step"]
+    ddd_export_command = [f'"{kicad_cli_path}"', "pcb", "export", "step"]
     type = "STEP"
     extension = "step"
   elif type == "VRML" or type == "vrml":
-    ddd_export_command = ["kicad-cli", "pcb", "export", "vrml"]
+    ddd_export_command = [f'"{kicad_cli_path}"', "pcb", "export", "vrml"]
     type = "VRML"
     extension = "wrl"
 
@@ -1230,8 +1249,11 @@ def generate3D (output_dir, pcb_filename, type = "STEP", to_overwrite = True):
 #=============================================================================================#
 
 def generateBom (output_dir, sch_filename, type, to_overwrite = True):
+  # Get the KiCad CLI path.
+  kicad_cli_path = f'{current_config.get ("kicad_cli_path", default_config ["kicad_cli_path"])}'
+
   # Common base command
-  bom_export_command = ["kicad-cli", "sch", "export", "bom"]
+  bom_export_command = [f'"{kicad_cli_path}"', "sch", "export", "bom"]
 
   # Check if the input file exists
   if not check_file_exists (sch_filename):
@@ -1333,8 +1355,11 @@ def generateBom (output_dir, sch_filename, type, to_overwrite = True):
 #=============================================================================================#
 
 def generateSvg (output_dir, pcb_filename, to_overwrite = True):
+  # Get the KiCad CLI path.
+  kicad_cli_path = f'{current_config.get ("kicad_cli_path", default_config ["kicad_cli_path"])}'
+
   # Common base command
-  pcb_svg_export_command = ["kicad-cli", "pcb", "export", "svg"]
+  pcb_svg_export_command = [f'"{kicad_cli_path}"', "pcb", "export", "svg"]
 
   # Check if the input file exists
   if not check_file_exists (pcb_filename):


### PR DESCRIPTION
- Added new `kicad_cli_path` configuration parameter.
  - This will help users to use different versions of KiCad CLI without adding it to the System Path.
  - `kicad_cli_path` will now be used by all generator functions.
- JSON configuration version updated to `1.3`.
- Did some initial testing with KiCad V9 RC3, and found to be working.
  - Some errors and warnings were found.
- New Version 🆕 `v0.0.28`.